### PR TITLE
add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /Cargo.lock
 /fuzz/Cargo.lock
+.idea


### PR DESCRIPTION
## What
add `.idea` folder to gitignore

## Why
[.idea is user-specific](https://www.jetbrains.com/help/idea/creating-and-managing-projects.html#directory-based), hence it should not be in VCS

This is helpful for folks using [IntelliJ Rust](https://www.jetbrains.com/rust/)